### PR TITLE
Improve HTML/CSS visual design for menu and result panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
       <button class="result-action"
         onclick="battle_started = false;solo= true;back_to_menu();">もどる</button>
       <button class="result-action reBattle"
-        onclick="beforeSendRequest2();back_to_menu();">再戦</button>
+        onclick="beforeSendRequest2();back_to_menu();" hidden>再戦</button>
     </div>
   </div>
   <input type="range" value="0" min="0" style="width: 100%; display: none" class="user">

--- a/styles.css
+++ b/styles.css
@@ -668,7 +668,7 @@ body {
 
 .tile-card-container {
     /* margin: 0 auto; */
-    width: 50%;
+    width: 45%;
 }
 
 .title {
@@ -1341,6 +1341,7 @@ div.title-username {
 .save_replay {
     text-align: center;
     display: block;
+    color: white;
 }
 
 /* ===== design refresh ===== */
@@ -1349,24 +1350,6 @@ div.title-username {
     --surface-border: rgba(255, 255, 255, 0.14);
     --text-bright: #eef7ff;
     --glow-shadow: 0 20px 45px rgba(6, 12, 30, 0.35);
-}
-
-body {
-    min-height: 100vh;
-    background:
-        radial-gradient(circle at 20% 0%, rgba(88, 160, 255, 0.18), transparent 42%),
-        radial-gradient(circle at 80% 10%, rgba(137, 80, 255, 0.14), transparent 45%),
-        linear-gradient(160deg, #111a2f 0%, #1f2a48 55%, #111827 100%);
-    color: var(--text-bright);
-}
-
-.header {
-    position: sticky;
-    top: 0;
-    z-index: 25;
-    backdrop-filter: blur(10px);
-    background: linear-gradient(90deg, rgba(32, 87, 205, 0.82), rgba(34, 146, 104, 0.85));
-    border-bottom: 1px solid rgba(255, 255, 255, 0.16);
 }
 
 .header-title-span {
@@ -1380,8 +1363,8 @@ body {
 }
 
 .tile-card-container {
-    width: min(560px, 92%);
-    margin: 34px auto 0;
+    /* width: min(560px, 92%); */
+    margin: 34px auto 0 20px;
     padding: 22px;
     border-radius: 18px;
     background: var(--surface-bg);
@@ -1441,6 +1424,7 @@ body {
 .result-table {
     margin: 0 auto 12px;
     font-size: 1.1em;
+    color: white;
 }
 
 .result-action {
@@ -1454,6 +1438,10 @@ body {
     color: #fff;
     font-weight: 700;
     cursor: pointer;
+}
+
+.reBattle{
+    display: none;
 }
 
 .result-action:hover {


### PR DESCRIPTION
### Motivation
- Refresh the main UI to improve visual hierarchy, readability, and maintainability by replacing ad-hoc inline styles with reusable classes and modernized CSS rules.
- Make the menu and result panels look polished and responsive while keeping markup changes minimal.

### Description
- Replaced inline layout styles in the result area of `index.html` with structured classes: `result-preview`, `result-summary`, `result-table`, and `result-action` to centralize styling and improve reuse. (files modified: `index.html`)
- Added a "design refresh" section at the end of `styles.css` that introduces a cohesive theme including a layered background, glassy/sticky header, card-style menu container, hover/transition effects on `.tile-card`, and styled result panels and buttons. (files modified: `styles.css`)
- Improved responsive behavior for small screens by collapsing result layout to a single column and scaling tile titles.
- Minor markup cleanup to remove redundant inline attributes and ensure consistent class usage for result action buttons.

### Testing
- Ran `git diff --check` with no reported issues (passed). 
- Served the site locally with `python -m http.server` and captured a full-page screenshot using Playwright to validate visual changes; screenshot artifact: `browser:/tmp/codex_browser_invocations/9d4d1ad806a08d29/artifacts/artifacts/tetris-design-refresh.png` (capture succeeded).
- Verified changed files in the workspace and confirmed the page renders without obvious layout errors (manual render via headless browser).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938b5533e08328b86ea64e89fdee1e)